### PR TITLE
refactor: modularize security layer and enable Swagger UI auth

### DIFF
--- a/backend-data-elaborator/api/src/main.py
+++ b/backend-data-elaborator/api/src/main.py
@@ -3,7 +3,7 @@ QuakeGuard Backend Service API
 -------------------------------
 Core API Gateway.
 Responsibilities:
-1. IoT Data Ingestion (ECDSA Validation).
+1. IoT Data Ingestion.
 2. Data Retrieval (REST).
 3. Real-Time Alert Distribution (Redis Pub/Sub -> WebSocket).
 """
@@ -11,41 +11,25 @@ Responsibilities:
 import json
 import asyncio
 import time
-import hashlib
 import os
-from datetime import datetime
 from typing import List
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Depends, HTTPException, status, WebSocket, WebSocketDisconnect, Request
-from fastapi.responses import JSONResponse
-from starlette.middleware.base import BaseHTTPMiddleware
 from sqlalchemy.orm import Session
-from sqlalchemy import func, desc, text
+from sqlalchemy import text
 from sqlalchemy.exc import OperationalError
 from redis import asyncio as aioredis
-
-# --- CRYPTOGRAPHY ---
-from ecdsa import VerifyingKey, NIST256p
-from ecdsa.util import sigdecode_der, sigdecode_string
 from geoalchemy2.elements import WKTElement
 
 # --- LOCAL MODULES ---
 from src.database import get_db, engine
 import src.models as models
 import src.schemas as schemas
+from src.security import verify_api_key, validate_iot_payload  # <--- IMPORTED SECURITY
 
 # --- CONFIGURATION ---
-MAX_TIMESTAMP_SKEW = 60
 REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
-
-# ⚠️ SECURITY: Shared Secret for Device Provisioning (Must match Firmware)
-ENROLLMENT_TOKEN = os.getenv("ENROLLMENT_TOKEN", "S3cret_Qu4k3_K3y")
-
-# ⚠️ SECURITY: API Key for IoT Endpoints
-IOT_API_KEY = os.getenv("IOT_API_KEY", "SuperSecretIoTKey2024")
-
-# ⚠️ SECURITY: Token for Mobile App WebSocket connections
 MOBILE_WS_TOKEN = os.getenv("MOBILE_WS_TOKEN", "SecretMobileAppToken2024")
 
 # ==========================================
@@ -53,7 +37,6 @@ MOBILE_WS_TOKEN = os.getenv("MOBILE_WS_TOKEN", "SecretMobileAppToken2024")
 # ==========================================
 
 def wait_for_db(retries: int = 10, delay: int = 3) -> None:
-    """Blocks startup until the PostgreSQL database is ready."""
     print("Checking Database connection...")
     for i in range(retries):
         try:
@@ -66,21 +49,15 @@ def wait_for_db(retries: int = 10, delay: int = 3) -> None:
             time.sleep(delay)
     raise Exception("❌ DB Connection Failed after multiple retries.")
 
-# 1. Initialize Database
 wait_for_db()
 models.Base.metadata.create_all(bind=engine)
-
-# 2. Initialize Redis Client (Async)
 redis_client = aioredis.from_url(REDIS_URL, decode_responses=True)
-
 
 # ==========================================
 # REAL-TIME NOTIFICATION SYSTEM (PUBSUB)
 # ==========================================
 
 class ConnectionManager:
-    """Manages active WebSocket connections for broadcasting alerts."""
-    
     def __init__(self):
         self.active_connections: List[WebSocket] = []
 
@@ -95,7 +72,6 @@ class ConnectionManager:
             print(f"📱 Client Disconnected. Active: {len(self.active_connections)}")
 
     async def broadcast(self, message: str) -> None:
-        """Pushes a message to all connected clients."""
         dead_connections = []
         for connection in self.active_connections:
             try:
@@ -104,14 +80,12 @@ class ConnectionManager:
                 print(f"⚠️ Failed to broadcast to a client: {e}")
                 dead_connections.append(connection)
                 
-        # Clean up any connections that threw errors
         for dead in dead_connections:
             self.disconnect(dead)
 
 manager = ConnectionManager()
 
 async def redis_alert_listener() -> None:
-    """Background Task: Subscribes to Redis 'quake_alerts' and broadcasts."""
     pubsub = redis_client.pubsub()
     await pubsub.subscribe("quake_alerts")
     print("🎧 Redis Pub/Sub Listener active on channel: 'quake_alerts'")
@@ -123,36 +97,16 @@ async def redis_alert_listener() -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Manages the startup and shutdown lifecycle of the FastAPI app."""
-    # Start the Pub/Sub listener in the background when the server starts
     listener_task = asyncio.create_task(redis_alert_listener())
     yield
-    # Clean up when the server shuts down
     listener_task.cancel()
 
-# 3. Initialize FastAPI
+# Initialize FastAPI
 app = FastAPI(title="QuakeGuard Backend", version="2.2.0", lifespan=lifespan)
 
 # ==========================================
-# SECURITY MIDDLEWARE & DEPENDENCIES
+# MIDDLEWARE
 # ==========================================
-
-class IoTAuthenticationMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request: Request, call_next):
-        if request.url.path.startswith(("/docs", "/openapi", "/health", "/ws")):
-            return await call_next(request)
-            
-        api_key = request.headers.get("X-API-Key")
-        
-        if api_key != IOT_API_KEY:
-            return JSONResponse(
-                status_code=401,
-                content={"detail": "Unauthorized: Invalid or missing X-API-Key header"}
-            )
-            
-        return await call_next(request)
-
-app.add_middleware(IoTAuthenticationMiddleware)
 
 async def rate_limiter(request: Request):
     """Fixed-window rate limiter using Redis."""
@@ -161,7 +115,6 @@ async def rate_limiter(request: Request):
     key = f"rate_limit:{client_ip}:{current_second}"
     
     request_count = await redis_client.incr(key)
-    
     if request_count == 1:
         await redis_client.expire(key, 5) 
         
@@ -171,15 +124,13 @@ async def rate_limiter(request: Request):
             detail="Rate limit exceeded. Too many requests from this IP."
         )
 
-# --- TASK #28: WEBSOCKET ENDPOINT ---
+# ==========================================
+# WEBSOCKET ENDPOINT
+# ==========================================
+
 @app.websocket("/ws/alerts")
 async def websocket_endpoint(websocket: WebSocket):
-    """Clients connect here to receive real-time updates."""
-    
-    # Extract the token from the connection query parameters
     token = websocket.query_params.get("token")
-    
-    # Reject unauthorized WebSocket connections instantly
     if token != MOBILE_WS_TOKEN:
         await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
         return
@@ -192,39 +143,11 @@ async def websocket_endpoint(websocket: WebSocket):
         manager.disconnect(websocket)
 
 # ==========================================
-# UTILITY: CRYPTO VERIFICATION
-# ==========================================
-
-def verify_device_signature(public_key_hex: str, message: str, signature_hex: str) -> bool:
-    if not public_key_hex or not signature_hex:
-        return False
-        
-    try:
-        key_bytes = bytes.fromhex(public_key_hex)
-        sig_bytes = bytes.fromhex(signature_hex)
-        message_bytes = message.encode('utf-8')
-
-        try:
-            vk = VerifyingKey.from_der(key_bytes)
-        except Exception:
-            vk = VerifyingKey.from_string(key_bytes, curve=NIST256p)
-        
-        try:
-            return vk.verify(sig_bytes, message_bytes, sigdecode=sigdecode_der, hashfunc=hashlib.sha256)
-        except Exception:
-            try:
-                return vk.verify(sig_bytes, message_bytes, sigdecode=sigdecode_string, hashfunc=hashlib.sha256)
-            except Exception:
-                return False
-    except Exception:
-        return False
-
-# ==========================================
 # REST API ENDPOINTS
 # ==========================================
 
 @app.post("/zones/", response_model=schemas.Zone, status_code=status.HTTP_201_CREATED, tags=["Registration"])
-def create_zone(zone: schemas.ZoneCreate, db: Session = Depends(get_db)):
+def create_zone(zone: schemas.ZoneCreate, db: Session = Depends(get_db), api_key: str = Depends(verify_api_key)):
     existing = db.query(models.Zone).filter(models.Zone.city == zone.city).first()
     if existing:
         return existing 
@@ -236,11 +159,11 @@ def create_zone(zone: schemas.ZoneCreate, db: Session = Depends(get_db)):
     return db_zone
 
 @app.get("/zones/", response_model=List[schemas.Zone], tags=["Data Retrieval"])
-def get_zones(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+def get_zones(skip: int = 0, limit: int = 100, db: Session = Depends(get_db), api_key: str = Depends(verify_api_key)):
     return db.query(models.Zone).offset(skip).limit(limit).all()
 
 @app.post("/misurators/", response_model=schemas.Misurator, status_code=status.HTTP_201_CREATED, tags=["Registration"])
-def create_misurator(misurator: schemas.MisuratorCreate, db: Session = Depends(get_db)):
+def create_misurator(misurator: schemas.MisuratorCreate, db: Session = Depends(get_db), api_key: str = Depends(verify_api_key)):
     existing = db.query(models.Misurator).filter(models.Misurator.public_key_hex == misurator.public_key_hex).first()
     if existing:
         return existing
@@ -264,45 +187,29 @@ def create_misurator(misurator: schemas.MisuratorCreate, db: Session = Depends(g
     return db_misurator
 
 @app.get("/misurators/", response_model=List[schemas.Misurator], tags=["Data Retrieval"])
-def get_misurators(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+def get_misurators(skip: int = 0, limit: int = 100, db: Session = Depends(get_db), api_key: str = Depends(verify_api_key)):
     return db.query(models.Misurator).offset(skip).limit(limit).all()
 
 @app.post("/misurations/", status_code=status.HTTP_202_ACCEPTED, tags=["Ingestion"], dependencies=[Depends(rate_limiter)])
-async def create_misuration_async(misuration: schemas.MisurationCreate, db: Session = Depends(get_db)):
-    misurator = db.query(models.Misurator).filter(models.Misurator.id == misuration.misurator_id).first()
-    if not misurator or not misurator.active:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sensor unauthorized")
-
-    # 1. Reconstruct Message
-    message = f"{misuration.value}:{int(misuration.device_timestamp)}"
+async def create_misuration_async(
+    # 💡 MAGIC HAPPENS HERE: validate_iot_payload handles all cryptography, replay checks, and API Key checks!
+    valid_data: dict = Depends(validate_iot_payload)
+):
+    # Extract the validated objects returned from our security module
+    misuration = valid_data["misuration"]
+    misurator = valid_data["misurator"]
     
-    # 2. Verify Signature
-    loop = asyncio.get_running_loop()
-    is_valid = await loop.run_in_executor(None, verify_device_signature, misurator.public_key_hex, message, misuration.signature_hex)
-
-    if not is_valid:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid digital signature")
-
-    # 3. Check Replay Attack
-    if abs(time.time() - misuration.device_timestamp) > 60:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Replay Attack Detected: Timestamp invalid")
-
-    # 4. Enqueue for Worker
+    # Enqueue for Worker
     payload = misuration.model_dump()
     payload['zone_id'] = misurator.zone_id
     
-    # Offload the rest to the Redis queue for async processing
+    # Offload to the Redis queue
     await redis_client.lpush("seismic_events", json.dumps(payload))
     return {"status": "accepted"}
 
 @app.get("/sensors/{id}/statistics", tags=["Data Retrieval"])
-def get_sensor_statistics(id: int, db: Session = Depends(get_db)):
-    """
-    Returns the total number of readings for a specific sensor.
-    """
+def get_sensor_statistics(id: int, db: Session = Depends(get_db), api_key: str = Depends(verify_api_key)):
     count = db.query(models.Misuration).filter(models.Misuration.misurator_id == id).count()
-    
-    # We can expand this later with Avg/Min/Max
     return {
         "sensor_id": id,
         "total_readings": count

--- a/backend-data-elaborator/api/src/security.py
+++ b/backend-data-elaborator/api/src/security.py
@@ -1,0 +1,84 @@
+import time
+import hashlib
+import asyncio
+import os
+from fastapi import Security, HTTPException, status, Depends
+from fastapi.security import APIKeyHeader
+from sqlalchemy.orm import Session
+from ecdsa import VerifyingKey, NIST256p
+from ecdsa.util import sigdecode_der, sigdecode_string
+
+from src.database import get_db
+import src.models as models
+import src.schemas as schemas
+
+# --- CONFIGURATION ---
+IOT_API_KEY = os.getenv("IOT_API_KEY", "SuperSecretIoTKey2024")
+
+# Define the Security Scheme for Swagger UI
+api_key_scheme = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+def verify_api_key(api_key: str = Security(api_key_scheme)):
+    """Dependency that checks the API Key and throws a 401 if invalid."""
+    if not api_key or api_key != IOT_API_KEY:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Unauthorized: Invalid or missing X-API-Key header"
+        )
+    return api_key
+
+def verify_device_signature(public_key_hex: str, message: str, signature_hex: str) -> bool:
+    """Validates the ECDSA signature from the IoT device."""
+    if not public_key_hex or not signature_hex:
+        return False
+        
+    try:
+        key_bytes = bytes.fromhex(public_key_hex)
+        sig_bytes = bytes.fromhex(signature_hex)
+        message_bytes = message.encode('utf-8')
+
+        try:
+            vk = VerifyingKey.from_der(key_bytes)
+        except Exception:
+            vk = VerifyingKey.from_string(key_bytes, curve=NIST256p)
+        
+        try:
+            return vk.verify(sig_bytes, message_bytes, sigdecode=sigdecode_der, hashfunc=hashlib.sha256)
+        except Exception:
+            try:
+                return vk.verify(sig_bytes, message_bytes, sigdecode=sigdecode_string, hashfunc=hashlib.sha256)
+            except Exception:
+                return False
+    except Exception:
+        return False
+
+async def validate_iot_payload(
+    misuration: schemas.MisurationCreate,
+    api_key: str = Depends(verify_api_key),
+    db: Session = Depends(get_db)
+):
+    """
+    Dependency that performs complete business-logic validation:
+    1. Validates the API Key.
+    2. Validates the Sensor exists and is active.
+    3. Prevents Replay Attacks.
+    4. Verifies the ECDSA Digital Signature.
+    """
+    misurator = db.query(models.Misurator).filter(models.Misurator.id == misuration.misurator_id).first()
+    if not misurator or not misurator.active:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sensor unauthorized")
+
+    # Check Replay Attack
+    if abs(time.time() - misuration.device_timestamp) > 60:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Replay Attack Detected: Timestamp invalid")
+
+    # Verify Signature
+    message = f"{misuration.value}:{int(misuration.device_timestamp)}"
+    loop = asyncio.get_running_loop()
+    is_valid = await loop.run_in_executor(None, verify_device_signature, misurator.public_key_hex, message, misuration.signature_hex)
+
+    if not is_valid:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid digital signature")
+
+    # If everything is valid, return the data so the endpoint can use it!
+    return {"misurator": misurator, "misuration": misuration}


### PR DESCRIPTION
## Overview
This PR introduces a major architectural refactor to the backend service. We transitioned from a monolithic `main.py` and clunky global middleware to a Clean Architecture model using FastAPI's native Dependency Injection. 

This resolves the issue where developers could not use the Swagger UI (`/docs`) to test endpoints due to missing API Key headers, while simultaneously making the codebase significantly cleaner, safer, and easier to maintain.

## Changes Made
* **Created `src/security.py`:** Centralized all IoT payload validation, including ECDSA cryptographic math, timestamp verification (Anti-Replay), and API key checks.
* **Deprecated Global Middleware:** Removed `IoTAuthenticationMiddleware`. By moving validation to Route Dependencies, we avoid FastAPI request body stream consumption bugs and correctly apply security only where needed.
* **Swagger UI Integration:** Implemented `APIKeyHeader` from `fastapi.security`. The `/docs` page now correctly displays the "Authorize" padlock button, allowing developers to inject `X-API-Key` automatically.
* **Endpoint Simplification:** Shrank `src/main.py` by approximately 100 lines. Endpoints like `/misurations/` now rely on a single, clean `Depends(validate_iot_payload)` injection to guarantee data authenticity before processing.

## Benefits
1. **Separation of Concerns:** `main.py` now acts strictly as an API routing gateway, completely agnostic to how elliptical curve cryptography functions.
2. **Developer Experience (DX):** API testing via Swagger UI is now fully functional.
3. **Performance & Security:** Cryptographic checks are now properly isolated and executed asynchronously via `loop.run_in_executor()`.

## Testing Performed
- [x] Verified Swagger UI displays the Authorize button and successfully authenticates requests using `X-API-Key`.
- [x] Ran E2E stress tests to ensure the new dependency correctly parses the `request.body` and validates ECDSA signatures under load.
- [x] Confirmed unauthorized requests and expired timestamps correctly return `401 Unauthorized` and `403 Forbidden` respectively.

Closes #59 