### PR TITLE
[Backend]sec: enforce strict environment variables and dynamic routing

### DIFF
--- a/backend-data-elaborator/api/docker-compose.yml
+++ b/backend-data-elaborator/api/docker-compose.yml
@@ -34,6 +34,8 @@ services:
     environment:
       - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       - REDIS_URL=redis://redis:6379/0
+      - IOT_API_KEY=${IOT_API_KEY}
+      - MOBILE_WS_TOKEN=${MOBILE_WS_TOKEN}
     depends_on:
       postgres:
         condition: service_healthy

--- a/backend-data-elaborator/api/src/main.py
+++ b/backend-data-elaborator/api/src/main.py
@@ -27,11 +27,14 @@ from geoalchemy2.elements import WKTElement
 from src.database import get_db, engine
 import src.models as models
 import src.schemas as schemas
-from src.security import verify_api_key, validate_iot_payload  # <--- IMPORTED SECURITY
+from src.security import verify_api_key, validate_iot_payload
 
-# --- CONFIGURATION ---
+# --- SECURE CONFIGURATION ---
 REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
-MOBILE_WS_TOKEN = os.getenv("MOBILE_WS_TOKEN", "SecretMobileAppToken2024")
+
+MOBILE_WS_TOKEN = os.getenv("MOBILE_WS_TOKEN")
+if not MOBILE_WS_TOKEN:
+    raise RuntimeError("🚨 CRITICAL STARTUP ERROR: 'MOBILE_WS_TOKEN' environment variable is not set!")
 
 # ==========================================
 # INFRASTRUCTURE INITIALIZATION

--- a/backend-data-elaborator/api/src/security.py
+++ b/backend-data-elaborator/api/src/security.py
@@ -13,7 +13,12 @@ import src.models as models
 import src.schemas as schemas
 
 # --- CONFIGURATION ---
-IOT_API_KEY = os.getenv("IOT_API_KEY", "SuperSecretIoTKey2024")
+IOT_API_KEY = os.getenv("IOT_API_KEY")
+
+# Define the Security Scheme for Swagger UI
+api_key_scheme = APIKeyHeader(name="X-API-Key", auto_error=False)
+if not IOT_API_KEY:
+    raise RuntimeError("🚨 CRITICAL STARTUP ERROR: 'IOT_API_KEY' environment variable is not set!")
 
 # Define the Security Scheme for Swagger UI
 api_key_scheme = APIKeyHeader(name="X-API-Key", auto_error=False)

--- a/frontend-mobile-app/constants/config.ts
+++ b/frontend-mobile-app/constants/config.ts
@@ -5,9 +5,13 @@
  * to ensure accessibility from physical devices or emulators.
  */
 
-export const API_BASE_URL = "http://10.228.201.82:8000"; 
+export const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL as string;
 
 // Centralized Security Secrets
-export const IOT_API_KEY = "SuperSecretIoTKey2024";
-export const MOBILE_WS_TOKEN = "SecretMobileAppToken2024";
+export const IOT_API_KEY = process.env.EXPO_PUBLIC_IOT_API_KEY as string;
+export const MOBILE_WS_TOKEN = process.env.EXPO_PUBLIC_MOBILE_WS_TOKEN as string;
 
+// Fail-fast logic for the frontend
+if (!IOT_API_KEY || !MOBILE_WS_TOKEN) {
+    console.warn("⚠️ CRITICAL WARNING: Missing EXPO_PUBLIC environment variables in frontend!")
+}


### PR DESCRIPTION
---
name: Pull Request
about: Standard PR format for all QuakeGuard contributions
title: "[Backend] sec: enforce strict environment variables and dynamic routing"
---

## Overview
This PR resolves a critical security vulnerability where API keys and WebSocket tokens were falling back to hardcoded strings in the source code. By removing these fallbacks and implementing a Fail-Fast architectural pattern, the backend will now proactively crash at startup if the required configuration is missing. This guarantees the application can never accidentally be deployed in a compromised, default-credential state, while also making the frontend routing fully dynamic.

## Changes Made
- `src/security.py` & `src/main.py`: Removed default fallback strings for `IOT_API_KEY` and `MOBILE_WS_TOKEN`. Implemented fail-fast startup validation that raises a RuntimeError if these secrets are missing from the environment.

- `docker-compose.yml`: Updated the fastapi-app service block to explicitly pass `IOT_API_KEY` and `MOBILE_WS_TOKEN` from the host environment down into the container.

- `constants/config.ts`: Completely eliminated hardcoded strings for both routing and security. The app now dynamically pulls `API_BASE_URL`, `IOT_API_KEY`, and `MOBILE_WS_TOKEN` using Expo's built-in `process.env.EXPO_PUBLIC_*` system.

<!-- 
Add one bullet per meaningful change. Be specific — mention file names,
function names, and architectural decisions. Avoid vague entries like "fixed bug".
-->

## Impact & Next Steps
⚠️ Action Required: Because default fallbacks have been removed, your local application will crash until you create the required .env files.

Developers must create a .env in the backend root and a .env in the React Native root containing the required keys.

This unblocks secure deployment to production/contest environments as no secrets remain in the repository.

## Testing Performed
- [x] Booted backend without a `.env` file and verified the application immediately raises a RuntimeError and refuses to start.

- [x] Added backend `.env` file, ran `docker compose up -d --build`, and verified the API and WebSocket server initialize successfully.

- [x] Added `EXPO_PUBLIC_` variables to the frontend .env, cleared Metro cache (`npx expo start -c`), and verified the mobile app successfully authenticates with the backend.

<!--
Be specific. Include what you ran, what environment you tested in,
and what the expected vs actual output was. For backend changes,
always include stress test results if relevant.
-->

## Related Issues
Closes #82
Closes #83
Closes #84
Closes #85
Closes #86