### PR TITLE
[CI] Add IoT firmware CI pipeline with PlatformIO build validation

### DIFF
--- a/.github/workflows/quakeguard-ci.yml
+++ b/.github/workflows/quakeguard-ci.yml
@@ -118,3 +118,45 @@ jobs:
         cd frontend-mobile-app
         # Run eslint on all JS/TS files
         npx eslint . --ext .js,.jsx,.ts,.tsx
+
+  # TASK #216: Add iot-ci job
+  iot-ci:
+    name: IoT Firmware Build Validation
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Source Code
+      uses: actions/checkout@v3
+
+    # We use Python to install the official PlatformIO Core CLI
+    - name: Setup Python Environment
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Cache PlatformIO Packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.platformio
+        key: ${{ runner.os }}-pio
+        restore-keys: |
+          ${{ runner.os }}-pio
+
+    # TASK #217: Install PlatformIO Core
+    - name: Install PlatformIO CLI
+      run: |
+        python -m pip install --upgrade pip
+        pip install platformio
+
+    # TASK #219: Inject dummy ENROLLMENT_TOKEN and configs
+    - name: Inject CI Environment Variables
+      run: |
+        cd iot-data-harvester/esp32_code
+        cp esp32_config.env.example esp32_config.env
+
+    # TASK #220: Run pio run to validate compilation
+    - name: Validate Firmware Compilation
+      run: |
+        cd iot-data-harvester/esp32_code
+        # This compiles the firmware based on platformio.ini but does not upload it
+        pio run

--- a/iot-data-harvester/esp32_code/esp32_config.env.example
+++ b/iot-data-harvester/esp32_code/esp32_config.env.example
@@ -37,3 +37,4 @@ SENSOR_ID=101
 # and stored securely in the device's NVS (Non-Volatile Storage) partition.
 #
 # Check the Serial Monitor output on boot to retrieve the Public Key.
+ENROLLMENT_TOKEN=key


### PR DESCRIPTION
---
name: Pull Request
about: Standard PR format for all QuakeGuard contributions
title: "[CI] Add IoT firmware CI pipeline with PlatformIO build validation"
---

## Overview
This PR introduces automated build validation for the ESP32 IoT firmware layer, addressing the lack of CI coverage for the C++ codebase. Previously, syntax errors, missing includes, or undefined environment variables were only caught during the manual flashing process. By adding a dedicated PlatformIO pipeline, we now ensure the firmware compiles cleanly on every push, satisfying compile-time checks without needing physical hardware. Resolves Issue #215.

## Changes Made
* **`.github/workflows/quakeguard-ci.yml`:** Appended the `iot-ci` job. This job provisions an Ubuntu runner, installs PlatformIO Core via Python, injects necessary dummy configurations, and executes `pio run`.
* **`iot-data-harvester/esp32_code/esp32_config.env.example`:** Created a CI-friendly dummy configuration file. Crucially, this includes a dummy `ENROLLMENT_TOKEN` to satisfy the C++ `#error` fail-fast validation added in previous PRs.

## Impact & Next Steps
This change significantly improves developer velocity and safety by catching entire classes of C++ and configuration errors before they reach hardware. 
* **Next Steps:** Future PRs can expand this pipeline to include C++ static analysis (e.g., `cppcheck`) or automated unit testing for the STA/LTA Ring Buffer logic using a framework like Unity.

## Testing Performed
- [x] Pushed branch to trigger GitHub Actions and verified the `iot-ci` job runs alongside Backend and Frontend jobs.
- [x] Verified PlatformIO CLI installs and caches correctly on the `ubuntu-latest` runner.
- [x] Injected an intentional C++ syntax error (`BREAK_THE_BUILD();`) and verified the CI pipeline explicitly fails (Task #221).
- [x] Removed the syntax error and verified `pio run` completes compilation with a green pipeline status.

## Related Issues
Closes #215, Closes #216, Closes #217, Closes #218, Closes #219, Closes #220, Closes #221