### PR TITLE
feat(backend): implement idempotent database seeding for global geogr…

### DIFF
--- a/backend-data-elaborator/api/src/main.py
+++ b/backend-data-elaborator/api/src/main.py
@@ -24,10 +24,11 @@ from redis import asyncio as aioredis
 from geoalchemy2.elements import WKTElement
 
 # --- LOCAL MODULES ---
-from src.database import get_db, engine
+from src.database import get_db, engine, SessionLocal
 import src.models as models
 import src.schemas as schemas
 from src.security import verify_api_key, validate_iot_payload
+from src.seed import seed_zones
 
 # --- SECURE CONFIGURATION ---
 REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
@@ -110,6 +111,9 @@ async def redis_alert_listener() -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    with SessionLocal() as db:
+        seed_zones(db)
+        
     listener_task = asyncio.create_task(redis_alert_listener())
     yield
     listener_task.cancel()
@@ -270,22 +274,19 @@ def register_device(payload: schemas.DeviceRegisterRequest, db: Session = Depend
     if existing:
         return {"sensor_id": existing.id}
 
-    # 3. Create a fallback Zone if none exist 
-    # TODO: This is a temporary pragmatic workaround for fresh databases.
-    # Supersede and remove this logic once the initial database seeding (Zone seeding) is implemented.
-    default_zone = db.query(models.Zone).first()
+    # 3. Retrieve the fallback Zone (guaranteed to exist via seeder)
+    default_zone = db.query(models.Zone).filter(models.Zone.city == "Unknown Region").first()
+    
+    # Failsafe just in case the db seeder was bypassed
     if not default_zone:
-        default_zone = models.Zone(city="Unassigned Provisioning Zone")
-        db.add(default_zone)
-        db.commit()
-        db.refresh(default_zone)
+        default_zone = db.query(models.Zone).first() 
 
     # 4. Save the new device
     new_device = models.Misurator(
         active=True,
         zone_id=default_zone.id,
-        latitude=0.0,  # Default fallback until updated via app
-        longitude=0.0, # Default fallback until updated via app
+        latitude=0.0, 
+        longitude=0.0, 
         public_key_hex=payload.public_key_hex,
         mac_address=payload.mac_address
     )
@@ -294,7 +295,6 @@ def register_device(payload: schemas.DeviceRegisterRequest, db: Session = Depend
     db.commit()
     db.refresh(new_device)
 
-    # 5. Return the exact JSON structure the ESP32 is waiting for!
     return {"sensor_id": new_device.id}
 
 @app.get("/misurators/", response_model=List[schemas.Misurator], tags=["Data Retrieval"])

--- a/backend-data-elaborator/api/src/models.py
+++ b/backend-data-elaborator/api/src/models.py
@@ -15,7 +15,13 @@ class Zone(Base):
     __tablename__ = "zones"
 
     id = Column(Integer, primary_key=True, index=True)
-    city = Column(String(100), nullable=False)
+    city = Column(String(100), nullable=False, unique=True)
+    
+    # Auditability timestamp
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    
+    # PostGIS Polygon boundary for automatic sensor assignment
+    geom = Column(Geometry('POLYGON', srid=4326), nullable=True)
 
     # Relationships
     misurators = relationship("Misurator", back_populates="zone", cascade="all, delete-orphan")

--- a/backend-data-elaborator/api/src/mqtt_subscriber.py
+++ b/backend-data-elaborator/api/src/mqtt_subscriber.py
@@ -18,12 +18,12 @@ def wait_for_api(retries=10, delay=3):
     print("Checking API connection...")
     for i in range(retries):
         try:
-            r = requests.get(API_HEALTH_URL)
+            r = requests.get(API_HEALTH_URL, timeout=5)
             if r.status_code == 200:
-                print("✅ API is healthy and ready!")
                 return
-        except Exception:
-            pass
+        except requests.exceptions.RequestException as e:
+            print(f"Health check failed: {e}")
+            
         print(f"⏳ Waiting for API... ({i+1}/{retries})")
         time.sleep(delay)
     raise RuntimeError("❌ API never became healthy")
@@ -36,7 +36,7 @@ def on_message(client, userdata, msg):
     try:
         payload = msg.payload.decode()
         headers = {"X-API-Key": IOT_API_KEY, "Content-Type": "application/json"}
-        response = requests.post(API_INGESTION_URL, data=payload, headers=headers)
+        response = requests.post(API_INGESTION_URL, data=payload, headers=headers, timeout=10)
         
         if response.status_code == 202:
             print("✅ Payload bridged successfully.")

--- a/backend-data-elaborator/api/src/seed.py
+++ b/backend-data-elaborator/api/src/seed.py
@@ -1,0 +1,55 @@
+"""
+Database Seeding Script
+-----------------------
+Pre-populates the database with global geographic macro-regions.
+Designed to be idempotent (safe to run multiple times).
+"""
+
+from sqlalchemy.orm import Session
+from geoalchemy2.elements import WKTElement
+import src.models as models
+
+# ==============================================================================
+# ⚠️ IMPLEMENTATION WARNING for Auto-Zone Assignment (Issue #199)
+# ==============================================================================
+# Some macro-regions below overlap geographically (e.g., "Italy - North" sits 
+# completely inside "Western Europe"). 
+# 
+# When implementing the ST_Contains spatial query for automatic sensor registration,
+# you MUST order the matched zones by polygon area in ASCENDING order.
+# 
+# Example PostGIS logic: ORDER BY ST_Area(geom) ASC LIMIT 1
+# This guarantees the sensor is assigned to the most specific (smallest) region.
+# ==============================================================================
+
+# Curated list of macro-regions. 
+# WKT Polygon format: POLYGON((min_lon min_lat, max_lon min_lat, max_lon max_lat, min_lon max_lat, min_lon min_lat))
+ZONES_DATA = [
+    {"city": "Italy - North", "geom": "POLYGON((6.6 44.0, 13.8 44.0, 13.8 47.1, 6.6 47.1, 6.6 44.0))"},
+    {"city": "Italy - Center", "geom": "POLYGON((9.7 41.2, 14.3 41.2, 14.3 44.0, 9.7 44.0, 9.7 41.2))"},
+    {"city": "Italy - South & Islands", "geom": "POLYGON((8.0 35.0, 18.5 35.0, 18.5 41.2, 8.0 41.2, 8.0 35.0))"},
+    {"city": "Western Europe", "geom": "POLYGON((-10.0 36.0, 20.0 36.0, 20.0 60.0, -10.0 60.0, -10.0 36.0))"},
+    {"city": "North America", "geom": "POLYGON((-168.0 15.0, -50.0 15.0, -50.0 75.0, -168.0 75.0, -168.0 15.0))"},
+    {"city": "South America", "geom": "POLYGON((-85.0 -55.0, -30.0 -55.0, -30.0 15.0, -85.0 15.0, -85.0 -55.0))"},
+    {"city": "East Asia", "geom": "POLYGON((73.0 15.0, 150.0 15.0, 150.0 55.0, 73.0 55.0, 73.0 15.0))"},
+    # The ultimate fallback region (No boundary constraints)
+    {"city": "Unknown Region", "geom": None} 
+]
+
+def seed_zones(db: Session):
+    print("🌱 Running database seeder for Zones...")
+    
+    for z_data in ZONES_DATA:
+        existing_zone = db.query(models.Zone).filter(models.Zone.city == z_data["city"]).first()
+        
+        if not existing_zone:
+            geom_elem = WKTElement(z_data["geom"], srid=4326) if z_data["geom"] else None
+            new_zone = models.Zone(
+                city=z_data["city"],
+                geom=geom_elem
+            )
+            db.add(new_zone)
+            print(f"   ➕ Created Zone: {z_data['city']}")
+            
+    db.commit()
+    print("✅ Seeding complete.")

--- a/backend-data-elaborator/api/tests/stress_test.py
+++ b/backend-data-elaborator/api/tests/stress_test.py
@@ -69,12 +69,15 @@ class MaliciousSensor(VirtualSensor):
 
 # --- UTILS (HTTP Provisioning) ---
 
-async def create_dynamic_zone(session: aiohttp.ClientSession) -> int:
-    city_name = f"TestZone_{uuid.uuid4().hex[:8]}"
-    async with session.post(f"{API_URL}/zones/", json={"city": city_name}) as resp:
-        if resp.status not in [200, 201]: raise Exception(f"Zone creation failed: {resp.status}")
-        data = await resp.json()
-        return data['id']
+async def get_test_zone(session: aiohttp.ClientSession) -> int:
+    """Fetches the ID of the seeded 'Unknown Region' zone to use for load testing."""
+    async with session.get(f"{API_URL}/zones/") as resp:
+        if resp.status != 200: 
+            raise Exception(f"Failed to fetch zones: {resp.status}")
+        
+        zones = await resp.json()
+        fallback_zone = next((z for z in zones if z["city"] == "Unknown Region"), zones[0])
+        return fallback_zone['id']
 
 async def register_sensor(session, sensor, zone_id, sem):
     async with sem:
@@ -237,10 +240,10 @@ async def main():
             
             # Setup
             try:
-                zone_id = await create_dynamic_zone(session)
+                zone_id = await get_test_zone(session) # <-- Use the fetch function instead
                 sensors = [VirtualSensor() for _ in range(NUM_SENSORS)]
                 await asyncio.gather(*[register_sensor(session, s, zone_id, sem) for s in sensors])
-                print(f"📝 Registered {NUM_SENSORS} sensors via HTTP.")
+                print(f"📝 Registered {NUM_SENSORS} sensors to Zone {zone_id}.")
             except Exception as e:
                 print(f"❌ Setup Failed: {e}")
                 return


### PR DESCRIPTION
---
name: Pull Request
about: Standard PR format for all QuakeGuard contributions
title: "feat(backend): implement global geographic zone seeding (#198)"
---

## Overview
This PR introduces an automated, idempotent database seeding mechanism to populate the `zones` table with curated global macro-regions (including PostGIS POLYGON boundaries) upon application startup. This eliminates the "chicken and egg" problem of requiring manual zone creation before sensors can be registered, laying the critical foundation for the upcoming autonomous sensor assignment feature.

## Changes Made
* **Data Models:** Added a `created_at` audit timestamp and a `geom` PostGIS `POLYGON` column to the `Zone` SQLAlchemy model.
* **Seeding Script (`src/seed.py`):** * Defined a list of major world regions with their WKT polygon coordinates.
  * Implemented an idempotent insertion loop that safely skips existing zones.
  * Added a designated "Unknown Region" fallback zone.
  * Documented the strict `ORDER BY ST_Area(geom) ASC` requirement for future spatial queries to handle overlapping regions (e.g., Northern Italy vs. Western Europe).
* **FastAPI Lifespan:** Hooked the `seed_zones` function into `src/main.py` to run synchronously after `create_all` and before the Redis listener starts. Resolved a missing `SessionLocal` import context error.
* **Testing Suite:** Refactored `stress_test.py` to query for the seeded "Unknown Region" instead of attempting to dynamically POST new zones during the test setup phase.

## Impact & Next Steps
Fresh Docker deployments will now boot with a fully populated and geographically structured database. This clears the blocker for **Issue #199**, allowing us to implement the `ST_Contains` spatial query that will auto-assign ESP32 devices to zones based on their GPS coordinates during provisioning.

## Testing Performed
- [x] Ran `docker compose down -v` and `docker compose up --build -d` to verify the seeding script executes successfully on a clean database.
- [x] Restarted the containers (`docker compose restart`) to verify the idempotency logic correctly skips re-inserting existing zones.
- [x] Verified the `NameError` for `SessionLocal` is resolved and the API boots to a healthy state.
- [x] Ran `python stress_test.py` and verified the load test successfully fetches and uses the seeded "Unknown Region".

## Related Issues
Closes #198. Unblocks #199.