### PR TITLE
feat(backend): add demo endpoint to trigger simulated alerts

### DIFF
--- a/backend-data-elaborator/api/src/main.py
+++ b/backend-data-elaborator/api/src/main.py
@@ -14,6 +14,7 @@ import time
 import os
 from typing import List
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 
 from fastapi import FastAPI, Depends, HTTPException, status, WebSocket, WebSocketDisconnect, Request
 from fastapi.responses import JSONResponse
@@ -234,6 +235,32 @@ async def health_check():
         
     return health_status
 
+@app.post("/demo/trigger-earthquake", status_code=status.HTTP_200_OK, tags=["Demo"])
+async def trigger_demo_earthquake(
+    payload: schemas.DemoAlertRequest,
+    api_key: str = Depends(verify_api_key)
+):
+    """
+    Instantly triggers a simulated CRITICAL earthquake alert.
+    Bypasses the IoT ingestion pipeline and broadcasts directly to all connected WebSocket clients.
+    """
+    # Construct the exact payload format expected by the frontend WebSocketContext
+    alert_data = {
+        "type": "CRITICAL",
+        "zone_id": payload.zone_id,
+        "magnitude": payload.magnitude,
+        "message": payload.message,
+        "timestamp": datetime.now(timezone.utc).isoformat()
+    }
+
+    # Publish directly to the Redis Pub/Sub channel
+    await redis_client.publish("quake_alerts", json.dumps(alert_data))
+
+    return {
+        "status": "success",
+        "detail": "Demo alert broadcasted successfully",
+        "payload": alert_data
+    }
 
 @app.post("/zones/", response_model=schemas.Zone, status_code=status.HTTP_201_CREATED, tags=["Registration"])
 def create_zone(zone: schemas.ZoneCreate, db: Session = Depends(get_db), api_key: str = Depends(verify_api_key)):

--- a/backend-data-elaborator/api/src/schemas.py
+++ b/backend-data-elaborator/api/src/schemas.py
@@ -91,3 +91,12 @@ class DeviceRegisterRequest(BaseModel):
     enrollment_token: str = Field(..., description="The hardcoded factory enrollment token")
     latitude: float = Field(default=0.0, ge=-90, le=90)
     longitude: float = Field(default=0.0, ge=-180, le=180)
+
+# ==========================================
+# DEMO SCHEMAS
+# ==========================================
+class DemoAlertRequest(BaseModel):
+    """Payload for manually triggering a simulated earthquake alert."""
+    zone_id: int = Field(default=1, description="Target Zone ID for the alert")
+    magnitude: float = Field(default=7.5, description="Simulated earthquake magnitude")
+    message: str = Field(default="Simulated Critical Event", description="Custom alert message")


### PR DESCRIPTION
---
name: Pull Request
about: Standard PR format for all QuakeGuard contributions
title: "feat(backend): add demo endpoint to trigger simulated alerts"
---

## Overview
This PR introduces a dedicated `POST /demo/trigger-earthquake` endpoint to solve the unreliability of demonstrating critical alerts during presentations and testing. Instead of waiting for the stress tester to randomly generate high-magnitude anomalies, developers can now trigger an immediate, customized CRITICAL payload directly from Swagger UI.

## Changes Made
* **`src/schemas.py`:** Added a `DemoAlertRequest` Pydantic model with default values (Magnitude 7.5) to allow one-click executions with an empty body.
* **`main.py`:** Created the `/demo/trigger-earthquake` route under the `tags=["Demo"]` group. Protected it with `Depends(verify_api_key)` and wired it directly to `redis_client.publish()`.

## Impact & Next Steps
This completely decouples frontend presentation testing from the backend statistical worker layer. We can now accurately test mobile push notifications, haptic patterns, and UI state changes instantly.
**Next Steps:** Document this endpoint in the developer onboarding guide so team members know how to test the frontend locally without spinning up the heavy Python worker container.

## Testing Performed
- [x] Verified the endpoint appears under the "Demo" tag in Swagger UI and correctly rejects unauthenticated requests (HTTP 401).
- [x] Triggered the endpoint with an empty body and verified a default Magnitude 7.5 payload successfully propagated to the frontend via WebSocket.
- [x] Overrode the defaults with a custom JSON body and verified the custom message/magnitude were correctly parsed and broadcast.

## Related Issues
Closes #191
Closes #192
Closes #193
Closes #194
Closes #195
Closes #196